### PR TITLE
Replace default MISP admin by "{{ misp_web_user }}"

### DIFF
--- a/tasks/misp-key-file.yml
+++ b/tasks/misp-key-file.yml
@@ -10,6 +10,11 @@
 - name: Key file
   when: not skey.stat.exists or skey.stat.size == 0
   block:
+    - name: Replace default MISP admin by "{{ misp_web_user }}" before running userInit
+      ansible.builtin.replace:
+        dest: "{{ misp_rootdir }}/app/Model/User.php"
+        regexp: 'admin@admin.test'
+        replace: "{{ misp_web_user }}"
     - name: Generate key file - cake userInit
       ansible.builtin.shell: "{{ misp_rootdir }}/app/Console/cake userInit -q | tee {{ misp_key_file }}"
       args:

--- a/tasks/misp-key-file.yml
+++ b/tasks/misp-key-file.yml
@@ -10,7 +10,7 @@
 - name: Key file
   when: not skey.stat.exists or skey.stat.size == 0
   block:
-    - name: Replace default MISP admin by "{{ misp_web_user }}" before running userInit
+    - name: Replace default MISP admin by "{{ misp_web_user }}"
       ansible.builtin.replace:
         dest: "{{ d }}"
         regexp: 'admin@admin.test'

--- a/tasks/misp-key-file.yml
+++ b/tasks/misp-key-file.yml
@@ -15,6 +15,9 @@
         dest: "{{ misp_rootdir }}/app/Model/User.php"
         regexp: 'admin@admin.test'
         replace: "{{ misp_web_user }}"
+        mode: '0640'
+        owner: "{{ www_user }}"
+        group: "{{ www_user }}"
     - name: Generate key file - cake userInit
       ansible.builtin.shell: "{{ misp_rootdir }}/app/Console/cake userInit -q | tee {{ misp_key_file }}"
       args:

--- a/tasks/misp-key-file.yml
+++ b/tasks/misp-key-file.yml
@@ -12,12 +12,16 @@
   block:
     - name: Replace default MISP admin by "{{ misp_web_user }}" before running userInit
       ansible.builtin.replace:
-        dest: "{{ misp_rootdir }}/app/Model/User.php"
+        dest: "{{ d }}"
         regexp: 'admin@admin.test'
         replace: "{{ misp_web_user }}"
         mode: '0640'
         owner: "{{ www_user }}"
         group: "{{ www_user }}"
+      loop:
+        - "{{ misp_rootdir }}/app/Model/User.php"
+      loop_control:
+        loop_var: d
     - name: Generate key file - cake userInit
       ansible.builtin.shell: "{{ misp_rootdir }}/app/Console/cake userInit -q | tee {{ misp_key_file }}"
       args:


### PR DESCRIPTION
By merging this request, we:

  * ensure we do have 'misp_web_user' set the way we expect;
  * we run this task before running `userInit`;
  * the default MISP admin user is set to admin@admin.test [0][1];
  * by replacing that on this block we ensure 'misp_web_user' is properly generated (key, passwd and permissions).

[0] https://github.com/MISP/MISP/blob/2.4/app/Model/User.php#L1066
[1] https://www.circl.lu/doc/misp/quick-start/