### PR TITLE
Set ssl_dir to its defaults on Ubuntu LTS versions, from 18.04 to 22.04

### DIFF
--- a/vars/Ubuntu-18.04.yml
+++ b/vars/Ubuntu-18.04.yml
@@ -109,7 +109,7 @@ mispmodules_libyarapath: /usr/local/lib/python3.6/dist-packages/usr/lib
 
 apacheetc: /etc/apache2
 ssl_user: ssl-cert
-ssl_dir: /etc/ssl
+ssl_dir: /etc/ssl/certs
 ssl_privatedir: /etc/ssl/private
 
 supervisor_conf: /etc/supervisor/supervisord.conf

--- a/vars/Ubuntu-20.04.yml
+++ b/vars/Ubuntu-20.04.yml
@@ -110,7 +110,7 @@ mispmodules_libyarapath: /usr/local/lib/python3.6/dist-packages/usr/lib
 
 apacheetc: /etc/apache2
 ssl_user: ssl-cert
-ssl_dir: /etc/ssl
+ssl_dir: /etc/ssl/certs
 ssl_privatedir: /etc/ssl/private
 
 supervisor_conf: /etc/supervisor/supervisord.conf

--- a/vars/Ubuntu-22.04.yml
+++ b/vars/Ubuntu-22.04.yml
@@ -120,7 +120,7 @@ mispmodules_libyarapath: /usr/local/lib/python3.10/dist-packages/usr/lib
 
 apacheetc: /etc/apache2
 ssl_user: ssl-cert
-ssl_dir: /etc/ssl
+ssl_dir: /etc/ssl/certs
 ssl_privatedir: /etc/ssl/private
 
 supervisor_conf: /etc/supervisor/supervisord.conf


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Set `ssl_dir` to its defaults on Ubuntu LTS versions, from 18.04 to 22.04

## Motivation and Context

By merging this one, we would be able to fix an erroneous configuration setting the `ssl_dir` variable to a value which does not reflect what's defined by default on Ubuntu.

According to one of Ubuntu's [official documentation](https://ubuntu.com/server/docs/security-certificates) the certificates live under `/etc/ssl/certs` instead of what was set before; `/etc/ssl`.

## How Has This Been Tested?

After changing the `misp_base_port` to `443` (which would require setting up TLS certificates), we:

* Applied this role, against _(fresh installed)_ Ubuntu machines using the particular versions affected by this change request;
* Verified the presence of a default value set as **`ETCCERTSDIR`** on `/usr/sbin/update-ca-certificates` (on the machines);
* Checked the list of files and their dependencies via `dpkg -S` and [packages repository information](https://packages.ubuntu.com/focal/all/ca-certificates/filelist) (e.g.: 20.04);
* Consulted the `update-ca-certificates(8)` manpage.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] ~~My change requires a change to the documentation.~~
- [ ] ~~I have updated the documentation accordingly.~~
- [ ] ~~I have read the **CONTRIBUTING** document.~~ _(this repository does not offer one)_
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed including pre-commit and github actions.
- [ ] Used in production.

<!--
https://www.talater.com/open-source-templates/#/page/1
-->
