### PR TITLE
Present the 'misp_webserver_harden' variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ misp_modules_enable: true
 mispmodules_rootdir: /opt
 misp_webserver: 'apache2'
 # misp_webserver: 'nginx'
+misp_webserver_harden: true
 misp_fcgi_enable: false
 misp_lief_enable: true
 misp_lief_rootdir: /var/lief

--- a/templates/apache2-misp.conf.j2
+++ b/templates/apache2-misp.conf.j2
@@ -40,7 +40,10 @@ Listen {{ misp_base_port }}
 {% endif %}
     SSLCertificateFile {{ ssl_dir }}/{{ ansible_fqdn }}.crt
     SSLCertificateKeyFile {{ ssl_privatedir }}/{{ ansible_fqdn }}.key
+
+{% if misp_webserver_harden %}
     Include {{ apacheetc }}/harden-apache2-https.conf
+{% endif %}
 
 {% else %}
     # If direct access without https, ensure CSP is not including


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Present the `misp_webserver_harden` variable, so we avoid depending on juju4/ansible-harden-apache, should we plan to have a clean setup also serving HTTPS.

## Motivation and Context

`templates/apache2-misp.conf.j2` was set to enforce the use of https://github.com/juju4/ansible-harden-apache, should we ended up setting the MISP role to serve HTTPS traffic by default. There was no option available to disable the inclusion of a particular configuration file which hardens the Apache virtual host.

Here we work that out, and present `misp_webserver_harden` (set to **true** by default), which gives folks an option to disable that if they want to.

## How Has This Been Tested?

After changing the `misp_base_port` to `443` (which would require setting up TLS certificates), we:

* Applied this role, against _(fresh installed)_ Ubuntu machines using the particular versions affected by this change request;
* Verified the presence (or not) of a included file for the `misp.conf` virtual host.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed including pre-commit and github actions.
- [ ] Used in production.

<!--
https://www.talater.com/open-source-templates/#/page/1
-->
