### PR TITLE
Add missing PHP script into the replacements loop from PR #13

### DIFF
--- a/tasks/misp-key-file.yml
+++ b/tasks/misp-key-file.yml
@@ -19,6 +19,7 @@
         owner: "{{ www_user }}"
         group: "{{ www_user }}"
       loop:
+        - "{{ misp_rootdir }}/app/Console/Command/Ls22Shell.php"
         - "{{ misp_rootdir }}/app/Model/User.php"
       loop_control:
         loop_var: d


### PR DESCRIPTION
## Description

Add missing PHP script into the replacements loop from PR #13

## Motivation and Context

The MISP application has its source under the `app/` directory. PR #13 took care of only once replacement, but there was a missing PHP script with **"admin@admin.test"** set statically on it which did not make it to that PR.

So, after [looking for more entries to replace](https://github.com/MISP/MISP/search?p=2&q=admin%40admin.test) and filtering out only the PHP-related code under `app/` we:

  * Replace the default admin user also on `app/Console/Command/Ls22Shell.php`;
  * This commit add that script to the loop and shall fix all PHP scripts with hard-coded entry for **"admin@admin.test"**.
  * 
## How Has This Been Tested?

Same as mentioned on pull request #13 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed including pre-commit and github actions.
- [ ] Used in production.

<!--
https://www.talater.com/open-source-templates/#/page/1
-->
