### PR TITLE
Add missing "php_bin" var into Ubuntu-20.04's

### DIFF
--- a/vars/Ubuntu-20.04.yml
+++ b/vars/Ubuntu-20.04.yml
@@ -102,6 +102,7 @@ php_confext: ini
 php_ini: /etc/php/7.4/apache2/php.ini
 php_ini_nginx: /etc/php/7.4/fpm/php.ini
 php_confenable: /etc/php/7.4/apache2/conf.d
+php_bin: /usr/bin/php7.4
 nginx_sock: /run/php/php7.4-fpm.sock
 fpm_user: www-data
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add missing `php_bin` var into Ubuntu-20.04's

## Motivation and Context

Ubuntu 20.04 is mentioned to be one of the recommended systems to run MISP on top of, so we setup variables used to configure recent Ubuntu 20 and 22 LTS systems to be present in both of the YAML var files.

## How Has This Been Tested?

Minor change, ran regular lint checks against YAML files and applied the role to a fresh installed VM.

  * _It's also possible to verify with alternative methods, like running a playbook to apply this role starting from particular tasks like, e.g.: `--start-at-task='Install PHP composer dependencies for background-jobs'`_

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed including pre-commit and github actions.
- [ ] Used in production.

<!--
https://www.talater.com/open-source-templates/#/page/1
-->
