### PR TITLE
Add MISP recommendations about PHP sessions settings

### DIFF
--- a/templates/misp-php.ini.j2
+++ b/templates/misp-php.ini.j2
@@ -6,3 +6,4 @@ memory_limit = 512M
 upload_max_filesize = 50M
 post_max_size = 50M
 session.sid_length = 32
+session.use_strict_mode = 1

--- a/templates/misp-php.ini.j2
+++ b/templates/misp-php.ini.j2
@@ -5,3 +5,4 @@ max_execution_time = 300
 memory_limit = 512M
 upload_max_filesize = 50M
 post_max_size = 50M
+session.sid_length = 32


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add MISP recommendations about PHP sessions settings

## Motivation and Context

Once we wave a new deployment of MISP and check the `/servers/serverSettings/diagnostics` route, there are quite a few tweaks one can plan to change in the system to improve a better experience while using (and maintaining) a MISP instance.

Here we are motivated to address the following:

  * Apply values recommended to setup (and harden) PHP sessions;
  * Ensure we have `use_strict_mode` set to **true**;
  * Ensure `sid-length` has at least **32** chars/bits (recommended by the PHP Project itself too).

## How Has This Been Tested?

* Applied this role, against fresh deployed machines using the particular versions affected by this change request;
* Logged as admin user and executed the MISP server's diagnostic checks;
* Verified if the template itself added the changes to `/etc/php/7.4/apache2/conf.d/99-misp.ini`;
  - that is a symlink to `/etc/php/7.4/mods-available/misp-php.ini`; 
  - it was tested on Debian/Ubuntu servers, that explains this path here.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed including pre-commit and github actions.
- [x] Used in production.

<!--
https://www.talater.com/open-source-templates/#/page/1
-->
