### PR TITLE
Add support to Debian 11 (bullseye)

### DIFF
--- a/.github/workflows/default-kitchen.yml
+++ b/.github/workflows/default-kitchen.yml
@@ -32,6 +32,7 @@ jobs:
             experimental: true
           - distribution: debian
             version: bullseye
+            version2: bullseye
             suite: default
             experimental: false
           - distribution: ubuntu

--- a/.github/workflows/default-kitchen.yml
+++ b/.github/workflows/default-kitchen.yml
@@ -30,6 +30,10 @@ jobs:
             version2: 8-Stream
             suite: default
             experimental: true
+          - distribution: debian
+            version: bullseye
+            suite: default
+            experimental: false
           - distribution: ubuntu
             version: '22.04'
             version2: 2204

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -25,6 +25,8 @@ jobs:
           - molecule_distro: 'centos:7'
             # SSL CERTIFICATE_VERIFY_FAILED remirepo
             experimental: true
+          - molecule_ditro: 'debian:bullseye'
+            experimental: false
           - molecule_distro: 'ubuntu:22.04'
             experimental: true
           - molecule_distro: 'ubuntu:20.04'

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -18,15 +18,14 @@ jobs:
       max-parallel: 4
       matrix:
         include:
+          - molecule_distro: 'centos:7'
+            experimental: true    # SSL CERTIFICATE_VERIFY_FAILED remirepo
+          - molecule_ditro: 'debian:bullseye'
+            experimental: false
           - molecule_distro: 'rockylinux:9'
             experimental: true
           - molecule_distro: 'rockylinux:8'
             experimental: true
-          - molecule_distro: 'centos:7'
-            # SSL CERTIFICATE_VERIFY_FAILED remirepo
-            experimental: true
-          - molecule_ditro: 'debian:bullseye'
-            experimental: false
           - molecule_distro: 'ubuntu:22.04'
             experimental: true
           - molecule_distro: 'ubuntu:20.04'

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -31,6 +31,7 @@ platforms:
   - name: ubuntu-20.04
   - name: centos-8
   - name: centos-7
+  - name: debian-bullseye
 
 suites:
   - name: default

--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -28,10 +28,10 @@ provisioner:
   ansible_connection: ssh
 
 platforms:
-  - name: ubuntu-20.04
   - name: centos-8
   - name: centos-7
   - name: debian-bullseye
+  - name: ubuntu-20.04
 
 suites:
   - name: default

--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -22,13 +22,13 @@ provisioner:
   ansible_cfg_path: test/vagrant/ansible.cfg
 
 platforms:
-  - name: ubuntu-20.04
   - name: centos-8
   - name: centos-7
     driver_config:
       network:
         - ["forwarded_port", {guest: 80, host: 8589}]
   - name: debian-bullseye
+  - name: ubuntu-20.04
 
 suites:
   - name: default

--- a/.kitchen.vagrant.yml
+++ b/.kitchen.vagrant.yml
@@ -28,6 +28,7 @@ platforms:
     driver_config:
       network:
         - ["forwarded_port", {guest: 80, host: 8589}]
+  - name: debian-bullseye
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -42,6 +42,7 @@ platforms:
     driver:
       config:
         security.privileged: true
+  - name: debian-bullseye
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -31,8 +31,6 @@ provisioner:
   ansible_omnibus_url: https://raw.githubusercontent.com/juju4/omnibus-ansible/master/ansible_install.sh
 
 platforms:
-  - name: ubuntu-22.04
-  - name: ubuntu-20.04
   - name: centos-9-Stream
   - name: centos-8-Stream
   - name: centos-7
@@ -43,6 +41,8 @@ platforms:
       config:
         security.privileged: true
   - name: debian-bullseye
+  - name: ubuntu-22.04
+  - name: ubuntu-20.04
 
 suites:
   - name: default

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 
-- name: Include version-specific variables for Ubuntu.
+- name: Include version-specific variables for Debian/Ubuntu
   ansible.builtin.include_vars: "{{ ansible_distribution }}-{{ ansible_distribution_version }}.yml"
-  when: ansible_distribution == 'Ubuntu'
+  when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 - name: Include version-specific variables for RedHat
   ansible.builtin.include_vars: "RedHat-{{ ansible_distribution_version.split('.')[0] }}.yml"
   when: ansible_os_family == "RedHat"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -536,6 +536,7 @@
     - { d: "{{ misp_rootdir }}/.gnupg/secring.gpg", m: '0600' }
   when: >
     not (
+          (ansible_distribution == 'Debian' and ansible_distribution_major_version | int >= 11) or
           (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int >= 18) or
           (ansible_os_family == "RedHat" and ansible_distribution_major_version | int >= 8)
         )

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -1,0 +1,121 @@
+---
+
+misp_pkg_list:
+ - openssh-server
+ - mysql-server
+ - php
+ - php-mysql
+ - php-mbstring
+ - php7.4-opcache
+ - php-readline
+ - php-mbstring
+ - php-zip
+ - php-redis
+ - php-gnupg
+ - php-intl
+ - php-bcmath
+ - php-gd
+ - postfix
+ - gcc
+ - zip
+ - git
+ - redis-server
+ - make
+ - python3-dev
+ - python3-pip
+ - python3-virtualenv
+ - python3-setuptools
+ - libxml2-dev
+ - libxslt1-dev
+ - libgl1-mesa-glx
+ - libzbar0
+ - zlib1g-dev
+ - php-dev
+ - curl
+ - gnupg
+ #
+ - php-redis
+ - python3-mysqldb
+ - rng-tools
+ # misp-modules
+ - python3
+ - libpq5
+ - acl
+ - sudo
+ - cron
+ ## pillow
+ - libtiff5-dev
+ - libjpeg8-dev
+ - zlib1g-dev
+ - libfreetype6-dev
+ ## if pyzmq?
+ # - libczmq-dev
+ - openssl
+ - libfuzzy-dev
+ - ruby-pygments.rb
+ - libsm6
+ - libzbar0
+ - libzbar-dev
+ - tesseract-ocr
+ - libpoppler-cpp-dev
+ - imagemagick
+ - libxrender1
+
+misp_gem_list:
+ - { name: public_suffix, v: 4.0.7 }
+ - { name: asciidoctor-pdf, v: 2.3.2 }
+
+python3_bin: python3
+python3_pip: pip3
+
+mysql_svc: mysql
+rng_svc: rng-tools
+redis_svc: redis
+redis_conf: /etc/redis/redis.conf
+misp_services:
+ - "{{ apache_svc }}"
+ - "{{ mysql_svc }}"
+ - "{{ rng_svc }}"
+
+misp_services_nginx:
+ - "{{ apache_svc }}"
+ - "{{ mysql_svc }}"
+ - "{{ rng_svc }}"
+ - php7.4-fpm
+
+misp_testing_pkg:
+ - ruby
+ - rake
+
+misp_webserver_apache2:
+ - apache2
+ - libapache2-mod-php
+ ## travis: "No package matching 'libapache2-mod-fastcgi' is available"
+ # - libapache2-mod-fastcgi
+
+misp_webserver_nginx:
+ - nginx
+ - php-fpm
+
+php_confdir: /etc/php/7.4/mods-available
+php_confext: ini
+php_ini: /etc/php/7.4/apache2/php.ini
+php_ini_nginx: /etc/php/7.4/fpm/php.ini
+php_confenable: /etc/php/7.4/apache2/conf.d
+php_bin: /usr/bin/php7.4
+nginx_sock: /run/php/php7.4-fpm.sock
+fpm_user: www-data
+
+gnupg_privdir: "{{ misp_rootdir }}/.gnupg/private-keys-v1.d"
+
+mispmodules_libyarapath: /usr/local/lib/python3.6/dist-packages/usr/lib
+
+apacheetc: /etc/apache2
+ssl_user: ssl-cert
+ssl_dir: /etc/ssl/certs
+ssl_privatedir: /etc/ssl/private
+
+supervisor_conf: /etc/supervisor/supervisord.conf
+supervisor_confdir: /etc/supervisor/conf.d
+supervisor_ext: conf
+supervisor_service: supervisor

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -45,7 +45,7 @@ misp_pkg_list:
  - cron
  ## pillow
  - libtiff5-dev
- - libjpeg8-dev
+ - libjpeg-dev
  - zlib1g-dev
  - libfreetype6-dev
  ## if pyzmq?

--- a/vars/Debian-11.yml
+++ b/vars/Debian-11.yml
@@ -2,7 +2,7 @@
 
 misp_pkg_list:
  - openssh-server
- - mysql-server
+ - mariadb-server
  - php
  - php-mysql
  - php-mbstring

--- a/vars/apache2-Debian.yml
+++ b/vars/apache2-Debian.yml
@@ -1,0 +1,12 @@
+---
+
+www_user: www-data
+apache_svc: apache2
+apache_confdir: /etc/apache2/conf-available
+apache_sitedir: /etc/apache2/sites-available
+apachesslconf: /etc/apache2/sites-enabled/default-ssl.conf
+apache_logs: /var/log/apache2
+modsecurity_conf: /etc/modsecurity/modsecurity.conf
+modsecurity_active: /usr/share/modsecurity-crs/activated_rules
+
+webserver: "{{ misp_webserver_apache2 }}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add support to Debian 11 (bullseye)

## Motivation and Context

According to the [INSTALL Documentation](https://github.com/MISP/MISP/tree/2.4/INSTALL) of the MISP Project, the installation procedures on top of Ubuntu 20.04 are being tested on a regular basic. That said, we decided to give it a shot and try running this implementation of an Ansible role on top of a Debian 11 (bullseye); it seems to be the closes system to what _"Focal Fossa"_ offers lately (with a little more reliability and stability[0][1][2]).

> $ flames >/dev/null

We also take the chance to offer an updated version of a Debian setup to folks that prefer that distribution over others -- recent [documentation](https://misp.github.io/MISP/xINSTALL.debian10) on the MISP Project website are covering only Debian 10 (buster).

[0] Ubuntu 20.04 currently falls under https://github.com/pyca/pyopenssl/issues/1114;
[1] `certbot` on Ubuntu 20.04 [requires](https://certbot.eff.org/instructions?ws=apache&os=ubuntufocal) that one uses **snap**;
[2] should folks rely on `node_exporter`, the package for Ubuntu 20.04 is [wonky](https://packages.ubuntu.com/focal/prometheus-node-exporter) - e.g.: it miscalculates NIC saturation;

## How Has This Been Tested?

* Fresh setup using Debian 11 (bullseye), from official project's [cloud images](https://cloud.debian.org/images/cloud/bullseye/latest/);
* Called the role directly as **root** (using _cloud-init_ credentials from the vanilla image);
* Opened a fresh instance of MISP, running on top of Debian 11;
* Server "survives" a reboot, still offering the regular web interface and `misp-modules`;
* Background jobs are running just fine;
* Plugin credentials added to the MISP configuration file, and service restarted w/o any blocker.

## Screenshots

![image](https://user-images.githubusercontent.com/651124/231121923-8742315b-5273-4446-b28f-4868e72efcc7.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed including pre-commit and github actions.
- [x] Used in production.

<!--
https://www.talater.com/open-source-templates/#/page/1
-->
