### PR TITLE
Update python / PHP, bugfixes and Rocky9/nginx support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -82,6 +82,18 @@ misp_webusers_list: []
 misp_email_contact: email@address.com
 misp_email_reply_to: misp-no-reply@localhost
 
+# Mail - Send using PHP mail function
+# Smtp - Send using SMTP
+# Debug - Do not send the email, just return the result
+misp_email_transport: "Mail"
+
+misp_email_sender_address: "site@localhost"
+misp_email_sender_name: "My Site"
+misp_email_host: "localhost"
+misp_email_port: 25
+misp_email_username: "user"
+misp_email_password: "secret"
+
 ## default provided feeds. you need to know their id
 misp_enable_feeds:
   # - CIRCL OSINT Feed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -538,6 +538,14 @@
   tags:
     - salt
 
+- name: Updating MISP email config
+  ansible.builtin.template:
+    src: "email.php.j2"
+    dest: "{{ misp_rootdir }}/app/Config/email.php"
+    mode: '0600'
+    backup: yes
+    owner: "{{ www_user }}"
+
 - name: Check if webroot gpg.asc exists
   ansible.builtin.stat:
     path: "{{ misp_rootdir }}/app/webroot/gpg.asc"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -36,6 +36,7 @@
     - misp_version == '2.5'
     - not (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int >= 24)
     - not (ansible_distribution == 'Debian' and ansible_distribution_major_version | int >= 12)
+    - ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Import debian
   ansible.builtin.import_tasks: debian.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -188,6 +188,13 @@
   ansible.builtin.stat:
     path: "{{ misp_rootdir }}/INSTALL"
   register: m
+
+- name: "Clear other files from MISP path"
+  file:
+    path: "{{ misp_rootdir }}"
+    state: absent
+  when: not m.stat.exists
+
 - name: Git clone MISP
   ansible.builtin.git:
     repo: https://github.com/MISP/MISP.git

--- a/tasks/misp-add-user.yml
+++ b/tasks/misp-add-user.yml
@@ -9,7 +9,7 @@
   args:
     chdir: "{{ misp_rootdir }}/PyMISP/examples"
   environment:
-    PYTHONPATH: /usr/local/lib/python3.6/site-packages
+    PYTHONPATH: /usr/local/lib/python3.12/site-packages
   when:
     - user.email is defined
     - list.stdout.find(user.email) == -1

--- a/tasks/misp-add-users.yml
+++ b/tasks/misp-add-users.yml
@@ -62,7 +62,7 @@
     chdir: "{{ misp_rootdir }}/PyMISP/examples"
   environment:
     debug: 'True'
-    PYTHONPATH: /usr/local/lib/python3.6/site-packages
+    PYTHONPATH: /usr/local/lib/python3.12/site-packages
   register: test
   changed_when: false
   ignore_errors: true
@@ -76,7 +76,7 @@
       args:
         chdir: "{{ misp_rootdir }}/PyMISP/examples"
       environment:
-        PYTHONPATH: /usr/local/lib/python3.6/site-packages
+        PYTHONPATH: /usr/local/lib/python3.12/site-packages
       register: listusers
       changed_when: false
   rescue:

--- a/tasks/misp-add-users.yml
+++ b/tasks/misp-add-users.yml
@@ -55,7 +55,7 @@
     timeout: 300
 
 - name: Ensure PyMISP API working
-  ansible.builtin.command: "{{ misp_virtualenv }}/bin/python ./last.py -l 10"
+  ansible.builtin.command: "{{ misp_virtualenv }}/bin/python -W ignore ./last.py -l 10"
   become: yes
   become_user: "{{ www_user }}"
   args:
@@ -70,7 +70,7 @@
 - name: Test MISP API
   block:
     - name: List current users
-      ansible.builtin.command: "{{ misp_virtualenv }}/bin/python ./users_list.py"
+      ansible.builtin.command: "{{ misp_virtualenv }}/bin/python -W ignore ./users_list.py"
       become: yes
       become_user: "{{ www_user }}"
       args:

--- a/tasks/misp-add-users.yml
+++ b/tasks/misp-add-users.yml
@@ -66,6 +66,9 @@
   register: test
   changed_when: false
   ignore_errors: true
+  retries: 3
+  delay: 5
+  until: test.rc == 0
 
 - name: Test MISP API
   block:
@@ -79,6 +82,9 @@
         PYTHONPATH: /usr/local/lib/python3.12/site-packages
       register: listusers
       changed_when: false
+      retries: 3
+      delay: 5
+      until: listusers.rc == 0
   rescue:
     - name: Check MISP logs
       ansible.builtin.command: "tail -n100 {{ misp_rootdir }}/app/tmp/logs/error.log {{ misp_rootdir }}/app/tmp/logs/debug.log"

--- a/tasks/mysql-configure.yml
+++ b/tasks/mysql-configure.yml
@@ -6,26 +6,14 @@
       community.mysql.mysql_db:
         name: misp
         state: present
-        login_user: "{{ misp_mysql_user | default(omit) }}"
-        login_password: "{{ misp_mysql_pass | default(omit) }}"
+        login_unix_socket: "/var/lib/mysql/mysql.sock"
       no_log: "{{ misp_no_log }}"
   rescue:
-    - name: Ensure db user has not empty password
-      community.mysql.mysql_user:
-        name: "{{ misp_mysql_user }}"
-        password: "{{ misp_mysql_pass }}"
-        state: present
-        login_user: "{{ misp_mysql_user }}"
-        login_password: ""
-      when:
-        - misp_mysql_user is defined and misp_mysql_user|length > 0
-        - misp_mysql_pass is defined and misp_mysql_pass|length > 0
     - name: Creating mysql misp db
       community.mysql.mysql_db:
         name: misp
         state: present
-        login_user: "{{ misp_mysql_user | default(omit) }}"
-        login_password: "{{ misp_mysql_pass | default(omit) }}"
+        login_unix_socket: "/var/lib/mysql/mysql.sock"
       no_log: "{{ misp_no_log }}"
 - name: Check if mysql import done
   ansible.builtin.stat:
@@ -46,8 +34,7 @@
     name: misp
     state: import
     target: "{{ misp_rootdir }}/INSTALL/MYSQL.sql"
-    login_user: "{{ misp_mysql_user | default(omit) }}"
-    login_password: "{{ misp_mysql_pass | default(omit) }}"
+    login_unix_socket: "/var/lib/mysql/mysql.sock"
   no_log: "{{ misp_no_log }}"
   when: not mispdbloaded.stat.exists
 - name: Add marker for mysql import
@@ -62,8 +49,7 @@
     password: "{{ misp_db_pass }}"
     priv: "*.*:USAGE/misp.*:ALL"
     state: present
-    login_user: "{{ misp_mysql_user | default(omit) }}"
-    login_password: "{{ misp_mysql_pass | default(omit) }}"
+    login_unix_socket: "/var/lib/mysql/mysql.sock"
   no_log: "{{ misp_no_log }}"
 
 - name: Ubuntu xenial

--- a/tasks/nginx.yml
+++ b/tasks/nginx.yml
@@ -12,6 +12,7 @@
     src: nginx-misp.conf.j2
     dest: "{{ apache_sitedir }}/misp.conf"
     mode: '0644'
+    force: no #this allows this file to be customized
   notify:
     - Restart webserver
 

--- a/tasks/php-conflict.yml
+++ b/tasks/php-conflict.yml
@@ -14,6 +14,8 @@
     cmd: update-alternatives --config php
   become: yes
   changed_when: false
+  when:
+      - ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
 
 - name: Set debian alternatives
   ansible.builtin.command:

--- a/tasks/redhat-remi.yml
+++ b/tasks/redhat-remi.yml
@@ -56,5 +56,5 @@
     - ansible_facts.packages['php-fpm'][0]['version'] is version_compare('7.4', '<')
 - name: RHEL8 | enable remi repository for php
   ansible.builtin.command:  # noqa no-changed-when
-    cmd: "dnf module enable php:remi-7.4 -y"
+    cmd: "dnf module enable php:remi-8.4 -y"
   when: ansible_distribution_major_version | int >= 8

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -53,7 +53,6 @@
     state: present
     update_cache: yes
   async: 3600
-  poll: 300
   register: pkg_result
   until: pkg_result is success
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -86,6 +86,7 @@
         - { re: '^;listen.group = nobody', rep: 'listen.group = {{ fpm_user }}' }
         - { re: '^listen.owner = .*$', rep: 'listen.owner = {{ fpm_user }}' }
         - { re: '^listen.group = .*$', rep: 'listen.group = {{ fpm_user }}' }
+        - { re: '^php_value\[session\.save_path] *= .*$', rep: 'php_value[session.save_path] = {{ misp_rootdir }}/app/tmp/sessions' }
       notify:
         - Restart php-fpm
 

--- a/tasks/selinux-context.yml
+++ b/tasks/selinux-context.yml
@@ -13,7 +13,7 @@
     - "{{ misp_rootdir }}/app/Plugin/CakeResque/tmp"
     - "{{ misp_rootdir }}/app/tmp"
     - "{{ misp_rootdir }}/app/tmp/cache/persistent"
-    - "{{ misp_rootdir }}/app/webroot/img/orgs"
+    - "{{ misp_rootdir }}/app/webroot/img/flags"
     - "{{ misp_rootdir }}/app/webroot/img/custom"
     - "{{ misp_rootdir }}/.gnupg"
     - "{{ misp_rootdir }}/app/Config/config.php"

--- a/templates/email.php.j2
+++ b/templates/email.php.j2
@@ -1,0 +1,106 @@
+<?php
+{{ ansible_managed | comment }}
+
+/**
+ * This is email configuration file.
+ *
+ * Use it to configure email transports of Cake.
+ *
+ * PHP 5
+ *
+ * CakePHP(tm) : Rapid Development Framework (http://cakephp.org)
+ * Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ *
+ * Licensed under The MIT License
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright 2005-2012, Cake Software Foundation, Inc. (http://cakefoundation.org)
+ * @link          http://cakephp.org CakePHP(tm) Project
+ * @package       app.Config
+ * @since         CakePHP(tm) v 2.0.0
+ * @license       MIT License (http://www.opensource.org/licenses/mit-license.php)
+ */
+/**
+ * In this file you set up your send email details.
+ *
+ * @package       cake.config
+ */
+
+/**
+ * Email configuration class.
+ * You can specify multiple configurations for production, development and testing.
+ *
+ * transport => The name of a supported transport; valid options are as follows:
+ *        Mail        - Send using PHP mail function
+ *        Smtp        - Send using SMTP
+ *        Debug        - Do not send the email, just return the result
+ *
+ * You can add custom transports (or override existing transports) by adding the
+ * appropriate file to app/Network/Email.  Transports should be named 'YourTransport.php',
+ * where 'Your' is the name of the transport.
+ *
+ * from =>
+ * The origin email. See CakeEmail::from() about the valid values
+ *
+ */
+class EmailConfig {
+
+	// to set the return-path header, simply uncomment the line below and change you@localhost to the desired e-mail address
+	public $default = array(
+		'transport'            => '{{ misp_email_transport | default('Mail') }}',
+		'from'                 => array('{{ misp_email_sender_address | default('site@localhost') }}' => '{{ misp_email_sender_name | default('My Site') }}'),
+		'host'                 => '{{ misp_email_host | default('localhost') }}',
+		'port'                 => {{ misp_email_port | default('25') }},
+		'username'             => '{{ misp_email_username | default('user') }}',
+		'password'             => '{{ misp_email_password | default('secret') }}',
+		'charset'              => 'utf-8',
+		'headers'              => array('Precedence' => 'bulk'),
+		//'additionalParameters' => '-f you@localhost'
+	);
+
+	public $smtp = array(
+		'transport'     => 'Smtp',
+		'from'          => array('site@localhost' => 'My Site'),
+		'host'          => 'localhost',
+		'port'          => 25,
+		'timeout'       => 30,
+		'username'      => 'user',
+		'password'      => 'secret',
+		'client'        => null,
+		'log'           => false,
+		//'charset'       => 'utf-8',
+		//'headerCharset' => 'utf-8',
+	);
+
+	public $fast = array(
+		'from'          => 'you@localhost',
+		'sender'        => null,
+		'to'            => null,
+		'cc'            => null,
+		'bcc'           => null,
+		'replyTo'       => null,
+		'readReceipt'   => null,
+		'returnPath'    => null,
+		'messageId'     => true,
+		'subject'       => null,
+		'message'       => null,
+		'headers'       => null,
+		'viewRender'    => null,
+		'template'      => false,
+		'layout'        => false,
+		'viewVars'      => null,
+		'attachments'   => null,
+		'emailFormat'   => null,
+		'transport'     => 'Smtp',
+		'host'          => 'localhost',
+		'port'          => 25,
+		'timeout'       => 30,
+		'username'      => 'user',
+		'password'      => 'secret',
+		'client'        => null,
+		'log'           => true,
+		//'charset'       => 'utf-8',
+		//'headerCharset' => 'utf-8',
+	);
+
+}

--- a/templates/systemd-misp-modules.service.j2
+++ b/templates/systemd-misp-modules.service.j2
@@ -12,7 +12,7 @@ Requires=network.target
 Type=simple
 User={{ www_user }}
 Group={{ www_user }}
-ExecStart={{ misp_virtualenv }}/bin/misp-modules -l 127.0.0.1 -s
+ExecStart={{ misp_virtualenv }}/bin/misp-modules
 Restart=on-failure
 RestartSec=15
 

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -26,8 +26,8 @@ misp_pkg_list:
  - git
  - redis
  - make
- - python3-devel
- - python3-pip
+ - python3.12-devel
+ - python3.12-pip
  - python3-virtualenv
  - python3-policycoreutils
  - policycoreutils-python-utils
@@ -40,8 +40,8 @@ misp_pkg_list:
  - "{% if (ansible_os_family == 'RedHat' and ansible_distribution_major_version | int >= 8) and ansible_virtualization_type is defined %}haveged{% else %}rng-tools{% endif %}"
  - wget
  # misp-modules
- - python3
- - python3-devel
+ - python3.12
+ - python3.12-devel
  - python3-PyMySQL
  - libpq
  ## misc
@@ -65,8 +65,8 @@ misp_pkg_list:
  - poppler-cpp-devel
  - ruby-devel
 
-python3_bin: python3
-python3_pip: /usr/bin/pip3
+python3_bin: python3.12
+python3_pip: /usr/bin/pip3.12
 
 misp_webserver_apache2:
  - httpd

--- a/vars/RedHat-9.yml
+++ b/vars/RedHat-9.yml
@@ -92,7 +92,7 @@ nginx_sock: /var/run/php-fpm/php-fpm.sock
 php_confdir: /etc/php.d
 php_confext: ini
 php_ini: /etc/php.ini
-php_remi_version: 74
+php_remi_version: 84
 fpm_user: nobody
 
 gnupg_privdir: "{{ misp_rootdir }}/.gnupg"

--- a/vars/nginx-Rocky.yml
+++ b/vars/nginx-Rocky.yml
@@ -1,0 +1,10 @@
+---
+
+webserver: "{{ misp_webserver_nginx }}"
+
+apache_svc: nginx
+www_user: nginx
+
+apache_sitedir: /etc/nginx/conf.d
+php_ini: /etc/php.ini
+fpm_user: nginx


### PR DESCRIPTION
I needed to update this role for my professional needs. My employer encourages contributing to upstream projects, and so I have prepared a fork with my changes.

The individual changes are split into separate commits so that you can pick and choose which ones you'd want to accept.

## Description of changes

### set PHP session path

The existing code does not configure the PHP session path by default and so at least on my install this wasn't working at all (MISP web authentication doesn't work without working sessions). I assume this path was intended to contain these files and thus this is what I have added to the config.

### debian-specific conditions missing

The existing code seems to only have been tested on Debian and thus I had to add these conditions that were probably intended, for the code to work on my Rocky9 install.

### selinux directory list update

Version 2.5 of MISP doesn't contain the "orgs" folder, so I replaced the path with one that exists.

### python 3.12 instead of python 3.6

Version 2.5 of MISP recommends Python 3.10 at least. I used 3.12, which seems to be a reasonable stable choice.

### PHP 8.4 instead of 7.4

Version 2.5 of MISP requires PHP 8+. I used 8.4, which seems to be a reasonable stable choice.

### MariaDB socket authentication

I don't believe the MySQL credentials are even contained in the defaults, only in the tests. I understand this is probably because this MISP install is being used on an already configured server by the main developer.

However regardless, newer MariaDB versions do not use a username and password, instead using the socket for authentication is appropriate. Also, as such, the test for a blank password is irrelevant.

### Rocky linux support

Rocky support for Nginx install was missing, I added the missing file.

### non-conflict with external webserver role

As mentioned in the docs an external nginx role is not required, but it is recommended for security. For me, the built-in functionality wasn't good enough as I needed SSL settings. These changes allow one to use an external role to configure nginx without the MISP role overwriting files which may contain additional settings.

### ignore PyMISP deprecation warnings

In the latest version of MISP, the files provided in the examples yield deprecation warnings. I opened a bug on the MISP project regarding this:
<https://github.com/MISP/PyMISP/issues/1325>

The changes included in this commit make the warnings be ignored.

### PyMISP retry

PyMISP commands tended to reliably fail the first time on my install, likely because of some difficult to account for startup delay. These changes add retries to make execution more clean by retrying automatically and only failing if retries are unsuccesful.

### remove legacy misp-modules parameters

In the latest version of MISP-modules, the `-s` parameter is meaningless and binding to localhost is default.

### reduce excessive software install delay

The existing code waits 300 seconds, or 5 minutes to check if the packages have been installed. This is extremely frustrating, especially on repeated runs where the install step doesn't need to do anything, when the code waits 5 minutes every time for no reason.

I see no particular reason why to not use the default 15 second delay instead. This is also much more appropriate for modern installs where internet is faster.

### email config support

I added support for sending email with SMTP using authentication.

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed including pre-commit and github actions.
- [X] Used in production.
